### PR TITLE
Fixed mysql authentication option causing db fail to start

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -43,7 +43,7 @@ services:
     command: 
       - "--event-scheduler=ON"
       - "--init-file=/tmp/common_init.sql"
-      - "--authentication_policy=mysql_native_password"
+      - "--mysql-native-password=ON"
 
   redis: #! used by fxa-profile-server(has prefixkey) fxa-content-server (seem not used?) fxa-auth-server(has prefix key)
     image: redis:6.0-alpine


### PR DESCRIPTION
The --default-authentication-plugin=mysql_native_password was removed from mysql 8.4 because native-password authentication is deprecated. In mysql 8.4 it's still possible to use the native_password authentication, but the parameter is renamed to --mysql-native-password=ON