### PR TITLE
remove 'version' from docker-compose.tmpl.yml

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -2,7 +2,6 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:assert", "assert")
 #@ load("@ytt:struct", "struct")
-version: "3.7"
 
 x-logging:
   &default-logging


### PR DESCRIPTION
fix for WARN: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion