### PR TITLE
Use user UID for yq in Docker

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -10,7 +10,7 @@ cp -r _init "${DEST}"/
 
 # define yq && ytt function
 yq() {
-  docker run --rm -i -v "${PWD}":/workdir:z mikefarah/yq:4.13.2 "$@"
+  docker run --rm -i --user "$UID" -v "${PWD}":/workdir:z mikefarah/yq:4.13.2 "$@"
 }
 
 yqw() {


### PR DESCRIPTION
Similar to yqw, the yq docker container should map the container user to the actual user running the container. This ensures container is allowed read / write on files. 

I was running this on Synology and it was not possible to run yq at all without this fix.
